### PR TITLE
Core 596

### DIFF
--- a/manifests/rule/rule_1_1.pp
+++ b/manifests/rule/rule_1_1.pp
@@ -33,12 +33,6 @@
 class cis_rhel7::rule::rule_1_1 {
   $file = '/etc/modprobe.d/CIS.conf'
 
-  file { '/etc/modprobe.d':
-    ensure => directory,
-    mode   => '0755',
-    owner  => 'root',
-    group  => 'root',
-  }
   file { $file :
     ensure => file,
     mode   => '0600',

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
  {
       "name": "cmc-linux_cis",
-      "version": "1.1.1",
+      "version": "1.1.2",
       "author": "Conclusion Mission Critical",
       "license": "Apache-2.0",
       "summary": "CIS Benchmark Compliance for RHEL 7",


### PR DESCRIPTION
De map modprobe.d werd in deze module gemanaged. Dat hoort niet in deze module thuis en de map bestaat ook altijd al.
De puppet module kmod gaan we gebruiken om Linux modules te managen en deze managed deze map ook. Dus verwijderen we hem van deze module.