### PR TITLE
Fixed rebuild of grub config when changed

### DIFF
--- a/manifests/rule/rule_4_1.pp
+++ b/manifests/rule/rule_4_1.pp
@@ -81,11 +81,9 @@ class cis_rhel7::rule::rule_4_1(
     owner  => 'root',
     group  => 'root',
   }
-  file_line { "(4.1.3) - ${grubfile}: audit=1":
+  kernel_parameter { 'audit':
     ensure => present,
-    path   => $grubfile,
-    line   => 'GRUB_CMDLINE_LINUX="nofb splash=quiet crashkernel=auto rd.lvm.lv=VolGroup01/root rhgb quiet audit=1"',
-    match  => '^GRUB_CMDLINE_LINUX',
+    value  => '1',
   }
   #4.1.4 t/m 4.1.18
   each ($rules) |$rule_item| {

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
  {
       "name": "cmc-linux_cis",
-      "version": "1.1.2",
+      "version": "1.1.3",
       "author": "Conclusion Mission Critical",
       "license": "Apache-2.0",
       "summary": "CIS Benchmark Compliance for RHEL 7",
@@ -20,6 +20,7 @@
        ],
       "dependencies": [
         { "name": "puppetlabs/stdlib", "version_requirement": ">= 2.2.0 < 5.0.0" },
-        { "name": "herculesteam-augeasproviders_pam", "version_requirement": ">= 2.1.0 < 5.0.0" }
+        { "name": "herculesteam-augeasproviders_pam", "version_requirement": ">= 2.1.0 < 3.0.0" },
+        { "name": "herculesteam-augeasproviders_grub", "version_requirement": ">= 3.0.0 < 4.0.0" }
       ]
     }


### PR DESCRIPTION
Voorheen werd audit=1 aan de grub commandline toegevoegd, maar de grub config werd nooit opnieuw gebouwd. Dus de parameter werd niet meegenomen bij een herstart.
Nu de augeas_grub module toegevoegd en daarmee de kernel_parameter gemanaged. Deze rebuild automagisch de grub opstart files en hierbij hoeft ook niet de hele line vervangen te worden. Voorheen werd dit met file_line gedaan en die regel is niet altijd hetzelfde. Dit is dus ook een stuk veiliger.