### PR TITLE
Core 630

### DIFF
--- a/manifests/rule/rule_3_3.pp
+++ b/manifests/rule/rule_3_3.pp
@@ -40,11 +40,14 @@ class cis_rhel7::rule::rule_3_3 (
       match  => '^net.ipv6.conf.default.accept_redirects',
     }
   }
-  if $disable_ipv6 {
-    file_line { "(3.3.3) ${file_cis} - disable ipv6":
-      ensure => present,
-      path   => $file_cis,
-      line   => 'options ipv6 disable=1',
+  kmod::option { 'ipv6':
+    option => 'disable',
+    value  => '1',
+    file   => $file_cis,
+    ensure => $disable_ipv6 ? {
+      true    => present,
+      false   => absent,
+      default => present,
     }
   }
 }

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
  {
       "name": "cmc-linux_cis",
-      "version": "1.1.3",
+      "version": "1.1.4",
       "author": "Conclusion Mission Critical",
       "license": "Apache-2.0",
       "summary": "CIS Benchmark Compliance for RHEL 7",


### PR DESCRIPTION
IPv6 wordt nu netjes weer verwijderd uit de CIS file als het niet uitgeschakeld hoeft te worden.