### PR TITLE
PAM CIS rule rewrite

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
  {
       "name": "cmc-linux_cis",
-      "version": "1.1.4",
+      "version": "1.1.5",
       "author": "Conclusion Mission Critical",
       "license": "Apache-2.0",
       "summary": "CIS Benchmark Compliance for RHEL 7",


### PR DESCRIPTION
PAM settings netjes met augeasproviders_pam gemanaged in plaats van file_lines. Tevens comform styleguide opgezet (alleen deze rule nog maar).
Getest op coredev. Werkt en is backwards compatible (er veranderd eigenlijk niets. Het wordt alleen netjes gemanaged en is instelbaar. Defaults zijn hetzelfde)
